### PR TITLE
Bugfixes and arch improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,6 +220,7 @@ dependencies = [
  "charon-lib",
  "evdev",
  "futures",
+ "lru_time_cache",
  "nix 0.30.1",
  "prometheus",
  "serde",
@@ -1072,6 +1073,12 @@ checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
  "hashbrown",
 ]
+
+[[package]]
+name = "lru_time_cache"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9106e1d747ffd48e6be5bb2d97fa706ed25b144fbee4d5c02eae110cd8d6badd"
 
 [[package]]
 name = "matchers"

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -21,3 +21,4 @@ wake-on-lan = "0.2.0"
 nix = { version = "0.30.1", features = ["term"] }
 # prometheus = { version = "0.14.0" }
 prometheus = { version = "0.14.0", features = ["push"] }
+lru_time_cache = "0.11.11"

--- a/crates/daemon/src/actor/ipc_server/ipc_server.rs
+++ b/crates/daemon/src/actor/ipc_server/ipc_server.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 
 use crate::domain::ActorState;
 use crate::domain::traits::Actor;
+use crate::error::CharonError;
 use charon_lib::event::{DomainEvent, Event};
 use tokio::sync::mpsc;
 use tokio::{net::UnixListener, task::JoinHandle};
@@ -56,12 +57,13 @@ impl Actor for IPCServer {
         "IPCServer"
     }
 
-    fn spawn(state: ActorState, (): ()) -> JoinHandle<()> {
+    fn spawn(state: ActorState, (): ()) -> Result<JoinHandle<()>, CharonError> {
         let path = state.config().server_socket.clone();
         let mut ipc_server = IPCServer::new(state, &path);
-        tokio::spawn(async move {
+        let handle = tokio::spawn(async move {
             ipc_server.run().await;
-        })
+        });
+        Ok(handle)
     }
 
     async fn tick(&mut self) {

--- a/crates/daemon/src/actor/pipeline.rs
+++ b/crates/daemon/src/actor/pipeline.rs
@@ -1,9 +1,12 @@
 use charon_lib::event::DomainEvent;
 use tokio::task::JoinHandle;
 
-use crate::domain::{
-    ActorState,
-    traits::{Actor, Processor},
+use crate::{
+    domain::{
+        ActorState,
+        traits::{Actor, Processor},
+    },
+    error::CharonError,
 };
 
 pub struct Pipeline {
@@ -19,11 +22,12 @@ impl Actor for Pipeline {
         "Pipeline"
     }
 
-    fn spawn(state: ActorState, processors: Self::Init) -> JoinHandle<()> {
+    fn spawn(state: ActorState, processors: Self::Init) -> Result<JoinHandle<()>, CharonError> {
         let mut actor = Pipeline { state, processors };
-        tokio::spawn(async move {
+        let handle = tokio::spawn(async move {
             actor.run().await;
-        })
+        });
+        Ok(handle)
     }
 
     async fn tick(&mut self) {

--- a/crates/daemon/src/actor/power_manager.rs
+++ b/crates/daemon/src/actor/power_manager.rs
@@ -4,7 +4,10 @@ use charon_lib::event::{DomainEvent, Event};
 use tokio::{process::Command, task::JoinHandle};
 use tracing::{error, info, warn};
 
-use crate::domain::{ActorState, traits::Actor};
+use crate::{
+    domain::{ActorState, traits::Actor},
+    error::CharonError,
+};
 
 pub struct PowerManager {
     state: ActorState,
@@ -80,11 +83,12 @@ impl Actor for PowerManager {
         "PowerManager"
     }
 
-    fn spawn(state: ActorState, (): ()) -> JoinHandle<()> {
+    fn spawn(state: ActorState, (): ()) -> Result<JoinHandle<()>, CharonError> {
         let mut power_mngr = PowerManager::new(state);
-        tokio::task::spawn(async move {
+        let handle = tokio::task::spawn(async move {
             power_mngr.run().await;
-        })
+        });
+        Ok(handle)
     }
 
     fn state(&self) -> &ActorState {

--- a/crates/daemon/src/actor/telemetry/telemetry.rs
+++ b/crates/daemon/src/actor/telemetry/telemetry.rs
@@ -36,11 +36,13 @@ impl Telemetry {
                 self.events.insert(event.id, event.timestamp);
             }
             DomainEvent::ReportConsumed() => {
-                self.events.remove(&event.source_event_id.unwrap());
+                if let Some(ref source_id) = event.source_event_id {
+                    self.events.remove(source_id);
+                }
             }
             DomainEvent::ReportSent() => {
-                if let Some(source_id) = event.source_event_id {
-                    if let Some(timestamp) = self.events.remove(&source_id) {
+                if let Some(ref source_id) = event.source_event_id {
+                    if let Some(timestamp) = self.events.remove(source_id) {
                         if let Some(diff) = event.timestamp.checked_sub(timestamp) {
                             self.metrics.register_key_to_report_time(diff);
                         }

--- a/crates/daemon/src/actor/typing_stats/typing_stats.rs
+++ b/crates/daemon/src/actor/typing_stats/typing_stats.rs
@@ -9,7 +9,10 @@ use tokio::{select, task::JoinHandle};
 use tracing::{error, info};
 
 use super::WPMCounter;
-use crate::domain::{ActorState, traits::Actor};
+use crate::{
+    domain::{ActorState, traits::Actor},
+    error::CharonError,
+};
 
 pub struct TypingStats {
     state: ActorState,
@@ -85,9 +88,9 @@ impl Actor for TypingStats {
         "TypingStats"
     }
 
-    fn spawn(state: ActorState, (): ()) -> JoinHandle<()> {
+    fn spawn(state: ActorState, (): ()) -> Result<JoinHandle<()>, CharonError> {
         let mut stats = TypingStats::new(state);
-        tokio::spawn(async move { stats.run().await })
+        Ok(tokio::spawn(async move { stats.run().await }))
     }
 
     async fn init(&mut self) {

--- a/crates/daemon/src/actor/typing_stats/wpm_counter.rs
+++ b/crates/daemon/src/actor/typing_stats/wpm_counter.rs
@@ -96,7 +96,7 @@ mod test {
 
         register_word(&mut wpm);
         wpm.next();
-        assert_eq!(2, wpm.wpm());
+        assert_eq!(1, wpm.wpm());
         assert_eq!(2, wpm.max_wpm());
 
         wpm.next();
@@ -120,7 +120,7 @@ mod test {
 
         register_word(&mut wpm);
         wpm.next();
-        assert_eq!(2, wpm.wpm());
+        assert_eq!(1, wpm.wpm());
         assert_eq!(2, wpm.max_wpm());
 
         wpm.next();

--- a/crates/daemon/src/adapter/evdev_input_source.rs
+++ b/crates/daemon/src/adapter/evdev_input_source.rs
@@ -1,0 +1,54 @@
+use std::collections::VecDeque;
+
+use evdev::{Device, InputEvent};
+use tokio::io::unix::AsyncFd;
+
+use crate::port::AsyncInputSource;
+
+pub struct EvdevInputSource {
+    device: AsyncFd<Device>,
+    pending: VecDeque<InputEvent>,
+}
+
+impl EvdevInputSource {
+    pub fn new(device: AsyncFd<Device>) -> Self {
+        Self {
+            device,
+            pending: VecDeque::new(),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl AsyncInputSource for EvdevInputSource {
+    async fn next_event(&mut self) -> Option<InputEvent> {
+        loop {
+            if let Some(ev) = self.pending.pop_front() {
+                return Some(ev);
+            }
+            let mut guard = self.device.readable_mut().await.ok()?;
+            let device = guard.get_mut().get_mut();
+
+            match device.fetch_events() {
+                Ok(events) => {
+                    self.pending.extend(events);
+                }
+                Err(_) => return None,
+            }
+
+            guard.clear_ready();
+        }
+    }
+
+    fn is_grabbed(&self) -> bool {
+        self.device.get_ref().is_grabbed()
+    }
+
+    fn grab(&mut self) -> std::io::Result<()> {
+        self.device.get_mut().grab()
+    }
+
+    fn ungrab(&mut self) -> std::io::Result<()> {
+        self.device.get_mut().ungrab()
+    }
+}

--- a/crates/daemon/src/adapter/evdev_input_source_mock.rs
+++ b/crates/daemon/src/adapter/evdev_input_source_mock.rs
@@ -1,0 +1,67 @@
+use evdev::{EventType, InputEvent, KeyCode};
+use std::{collections::VecDeque, sync::Arc};
+use tokio::{
+    sync::Mutex,
+    time::{Duration, sleep},
+};
+
+use crate::port::AsyncInputSource;
+
+#[derive(Default)]
+pub struct MockState {
+    pub grabbed: bool,
+    pub grab_calls: u16,
+    pub ungrab_calls: u16,
+    pub events: VecDeque<InputEvent>,
+}
+
+impl MockState {
+    pub fn simulate_key_press(&mut self, key_code: KeyCode) {
+        let event = InputEvent::new_now(EventType::KEY.0, key_code.code(), 1);
+        self.events.push_back(event);
+    }
+
+    pub fn simulate_key_release(&mut self, key_code: KeyCode) {
+        let event = InputEvent::new_now(EventType::KEY.0, key_code.code(), 0);
+        self.events.push_back(event);
+    }
+}
+
+#[derive(Default)]
+pub struct EvdevInputSourceMock {
+    pub state: Arc<Mutex<MockState>>,
+}
+
+impl EvdevInputSourceMock {
+    pub fn state(&self) -> &Arc<Mutex<MockState>> {
+        &self.state
+    }
+}
+
+#[async_trait::async_trait]
+impl AsyncInputSource for EvdevInputSourceMock {
+    async fn next_event(&mut self) -> Option<InputEvent> {
+        sleep(Duration::from_millis(1)).await;
+        let mut lock = self.state.lock().await;
+        return lock.events.pop_front();
+    }
+
+    fn is_grabbed(&self) -> bool {
+        let lock = self.state.try_lock().expect("Couldn't lock the state");
+        return lock.grabbed;
+    }
+
+    fn grab(&mut self) -> std::io::Result<()> {
+        let mut lock = self.state.try_lock().expect("Couldn't lock the state");
+        lock.grabbed = true;
+        lock.grab_calls += 1;
+        Ok(())
+    }
+
+    fn ungrab(&mut self) -> std::io::Result<()> {
+        let mut lock = self.state.try_lock().expect("Couldn't lock the state");
+        lock.grabbed = false;
+        lock.ungrab_calls += 1;
+        Ok(())
+    }
+}

--- a/crates/daemon/src/adapter/mod.rs
+++ b/crates/daemon/src/adapter/mod.rs
@@ -1,0 +1,6 @@
+mod evdev_input_source;
+
+#[cfg(test)]
+pub mod evdev_input_source_mock;
+
+pub use evdev_input_source::EvdevInputSource;

--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -55,7 +55,9 @@ impl Daemon {
 
     pub async fn shutdown(&mut self) {
         for handle in self.tasks.drain(..) {
-            handle.await.unwrap();
+            if let Err(err) = handle.await {
+                error!("Error while sutting down an actor: {err}");
+            }
         }
     }
 

--- a/crates/daemon/src/devices/evdev.rs
+++ b/crates/daemon/src/devices/evdev.rs
@@ -4,7 +4,7 @@ use std::{
     path::PathBuf,
 };
 
-use tracing::{debug, info};
+use tracing::{debug, error, info};
 
 use crate::config::InputConfig;
 
@@ -22,7 +22,7 @@ pub(crate) fn find_input_device(conf: &InputConfig) -> Option<PathBuf> {
     if let Some(device) = &maybe_device {
         info!("Keyboard found: {:?}", device);
     } else {
-        info!("Device not found for {:?}", conf);
+        error!("Device not found for {:?}", conf);
     }
 
     maybe_device

--- a/crates/daemon/src/devices/hid_keyboard.rs
+++ b/crates/daemon/src/devices/hid_keyboard.rs
@@ -1,7 +1,7 @@
 use std::{
     fs::{File, OpenOptions},
     io::Write,
-    path::PathBuf,
+    path::Path,
 };
 
 use tracing::error;
@@ -11,7 +11,7 @@ pub struct HIDKeyboard {
 }
 
 impl HIDKeyboard {
-    pub fn new(path: &PathBuf) -> Self {
+    pub fn new(path: &Path) -> Self {
         let hidg = OpenOptions::new()
             .write(true)
             .open(path)

--- a/crates/daemon/src/domain/hid_keycode.rs
+++ b/crates/daemon/src/domain/hid_keycode.rs
@@ -1,7 +1,7 @@
 use evdev::KeyCode;
 use std::{fmt, str::FromStr};
 
-use crate::error::KOSError;
+use crate::error::CharonError;
 
 /// Represents a USB HID Usage ID for a key.
 /// See: https://www.usb.org/sites/default/files/hut1_3_0.pdf for details
@@ -143,7 +143,7 @@ impl HidKeyCode {
         0
     }
 
-    pub fn seq_from_char(c: char) -> Result<Vec<Self>, KOSError> {
+    pub fn seq_from_char(c: char) -> Result<Vec<Self>, CharonError> {
         use HidKeyCode::*;
         let mut seq = Vec::with_capacity(4);
         let mut c = c;
@@ -202,7 +202,7 @@ impl HidKeyCode {
             ',' => KEY_COMMA,
             '.' => KEY_DOT,
             '/' => KEY_SLASH,
-            _ => return Err(KOSError::UnsupportedCharacter(c)),
+            _ => return Err(CharonError::UnsupportedCharacter(c)),
         };
 
         seq.push(key_code);
@@ -217,7 +217,7 @@ impl From<HidKeyCode> for u8 {
 }
 
 impl TryFrom<u8> for HidKeyCode {
-    type Error = KOSError;
+    type Error = CharonError;
 
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         use HidKeyCode::*;
@@ -338,7 +338,7 @@ impl TryFrom<u8> for HidKeyCode {
             0xE6 => KEY_RIGHTALT,
             0xE7 => KEY_RIGHTMETA,
 
-            _ => return Err(KOSError::UnsupportedCharacter(value.into())),
+            _ => return Err(CharonError::UnsupportedCharacter(value.into())),
         };
         Ok(val)
     }
@@ -350,13 +350,13 @@ macro_rules! match_key {
             $(
                 KeyCode::$name => HidKeyCode::$name,
             )*
-            other => return Err(KOSError::UnsupportedKeyCode(other)),
+            other => return Err(CharonError::UnsupportedKeyCode(other)),
         }
     };
 }
 
 impl TryFrom<&KeyCode> for HidKeyCode {
-    type Error = KOSError;
+    type Error = CharonError;
 
     fn try_from(kc: &KeyCode) -> Result<Self, Self::Error> {
         Ok(match_key!(
@@ -585,7 +585,7 @@ impl fmt::Display for HidKeyCode {
 }
 
 impl FromStr for HidKeyCode {
-    type Err = KOSError;
+    type Err = CharonError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use HidKeyCode::*;
@@ -667,7 +667,7 @@ impl FromStr for HidKeyCode {
             "RIGHT" => KEY_RIGHT,
             "NUMLOCK" => KEY_NUMLOCK,
             "SCROLLLOCK" => KEY_SCROLLLOCK,
-            other => return Err(KOSError::UnsupportedKeyName(other.into())),
+            other => return Err(CharonError::UnsupportedKeyName(other.into())),
         };
         Ok(key)
     }

--- a/crates/daemon/src/domain/key_shortcut.rs
+++ b/crates/daemon/src/domain/key_shortcut.rs
@@ -1,6 +1,6 @@
 use std::{fmt, str::FromStr};
 
-use crate::error::KOSError;
+use crate::error::CharonError;
 
 use super::{HidKeyCode, Modifiers};
 
@@ -17,12 +17,12 @@ impl KeyShortcut {
 }
 
 impl FromStr for KeyShortcut {
-    type Err = KOSError;
+    type Err = CharonError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let parts: Vec<&str> = s.split('+').collect();
         if parts.is_empty() {
-            return Err(KOSError::InvalidKeyShortcut(s.into()));
+            return Err(CharonError::InvalidKeyShortcut(s.into()));
         }
 
         let mut modifiers = Modifiers::default();
@@ -35,7 +35,7 @@ impl FromStr for KeyShortcut {
                     "shift" => modifiers.add(Modifiers::LEFT_SHIFT),
                     "alt" => modifiers.add(Modifiers::LEFT_ALT),
                     "meta" | "cmd" | "super" => modifiers.add(Modifiers::LEFT_META),
-                    _ => return Err(KOSError::InvalidKeyShortcut(s.into())),
+                    _ => return Err(CharonError::InvalidKeyShortcut(s.into())),
                 }
             }
         }

--- a/crates/daemon/src/domain/traits/actor.rs
+++ b/crates/daemon/src/domain/traits/actor.rs
@@ -4,7 +4,7 @@ use charon_lib::event::{DomainEvent, Event};
 use tokio::task::JoinHandle;
 use tracing::{info, warn};
 
-use crate::domain::ActorState;
+use crate::{domain::ActorState, error::CharonError};
 
 #[async_trait::async_trait]
 pub trait Actor {
@@ -73,5 +73,5 @@ pub trait Actor {
     async fn init(&mut self) {}
     async fn shutdown(&mut self) {}
 
-    fn spawn(state: ActorState, init: Self::Init) -> JoinHandle<()>;
+    fn spawn(state: ActorState, init: Self::Init) -> Result<JoinHandle<()>, CharonError>;
 }

--- a/crates/daemon/src/error.rs
+++ b/crates/daemon/src/error.rs
@@ -4,7 +4,7 @@ use thiserror;
 use tokio::sync::mpsc::error::SendError;
 
 #[derive(Debug, thiserror::Error)]
-pub enum KOSError {
+pub enum CharonError {
     #[error("Couldn't handle the keycode: {0:?}")]
     UnsupportedKeyCode(KeyCode),
 
@@ -20,9 +20,15 @@ pub enum KOSError {
     #[error("Unsupported key name: {0}")]
     UnsupportedKeyName(String),
 
+    #[error("Couldn't find requested keyboard: {0}")]
+    KeyboardNotFound(String),
+
     #[error("Event channel error: {0}")]
     EventChannelError(#[from] SendError<Event>),
 
     #[error("IO error: {0}")]
     IOError(#[from] std::io::Error),
+
+    #[error("Prometheus error: {0}")]
+    PrometheusError(#[from] prometheus::Error),
 }

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -1,10 +1,12 @@
 pub mod actor;
+pub mod adapter;
 pub mod broker;
 pub mod config;
 pub mod daemon;
 pub mod devices;
 pub mod domain;
 pub mod error;
+pub mod port;
 pub mod processor;
 pub mod util;
 

--- a/crates/daemon/src/port/async_input_source.rs
+++ b/crates/daemon/src/port/async_input_source.rs
@@ -1,0 +1,9 @@
+use evdev::InputEvent;
+
+#[async_trait::async_trait]
+pub trait AsyncInputSource: Send {
+    async fn next_event(&mut self) -> Option<InputEvent>;
+    fn is_grabbed(&self) -> bool;
+    fn grab(&mut self) -> std::io::Result<()>;
+    fn ungrab(&mut self) -> std::io::Result<()>;
+}

--- a/crates/daemon/src/port/mod.rs
+++ b/crates/daemon/src/port/mod.rs
@@ -1,0 +1,3 @@
+mod async_input_source;
+
+pub use async_input_source::AsyncInputSource;

--- a/crates/daemon/src/processor/system_shortcut_processor.rs
+++ b/crates/daemon/src/processor/system_shortcut_processor.rs
@@ -98,11 +98,10 @@ impl Processor for SystemShortcutProcessor {
     async fn process(&mut self, event: Event) -> Vec<Event> {
         match &event.payload {
             DomainEvent::HidReport(report) => {
-                if self
-                    .handle_report(&report, event.source_event_id.unwrap())
-                    .await
-                {
-                    self.events.push(event);
+                if let Some(source_id) = event.source_event_id {
+                    if self.handle_report(&report, source_id).await {
+                        self.events.push(event);
+                    }
                 }
             }
             _ => self.events.push(event),

--- a/crates/daemon/src/processor/system_shortcut_processor.rs
+++ b/crates/daemon/src/processor/system_shortcut_processor.rs
@@ -38,7 +38,6 @@ impl SystemShortcutProcessor {
             return self.state.mode().await == Mode::PassThrough;
         }
 
-        self.send_telemetry(parent_id);
         self.reset_hid(parent_id);
         false
     }
@@ -68,18 +67,6 @@ impl SystemShortcutProcessor {
                 Ok(_) => info!("Magic packet sent"),
                 Err(e) => error!("Error while sendimg magic packet: {e}"),
             }
-        }
-    }
-
-    fn send_telemetry(&mut self, parent_id: Uuid) {
-        let config = self.state.config();
-        if config.enable_telemetry {
-            let event = Event::with_source_id(
-                self.state.id.clone(),
-                DomainEvent::ReportConsumed(),
-                parent_id,
-            );
-            self.events.push(event);
         }
     }
 

--- a/crates/daemon/src/util/mod.rs
+++ b/crates/daemon/src/util/mod.rs
@@ -1,1 +1,4 @@
 pub mod system;
+
+#[cfg(test)]
+pub mod test;

--- a/crates/daemon/src/util/test.rs
+++ b/crates/daemon/src/util/test.rs
@@ -1,0 +1,26 @@
+#[macro_use]
+pub(crate) mod macros {
+
+    macro_rules! with_lock {
+        ($mutex:expr, |$lock:ident| $body:block) => {{
+            let $lock = $mutex.lock().await;
+            $body
+        }};
+    }
+
+    macro_rules! assert_event_matches {
+        ($rx:expr, $pat:pat $(if $guard:expr)? $(,)?) => {{
+            let event = $rx.recv().await.expect("Expected an event");
+            match &event.payload {
+                $pat $(if $guard)? => {},
+                other => panic!(
+                    "Unexpected event: {:?}, expected pattern: {}",
+                    other,
+                    stringify!($pat)
+                ),
+            }
+        }};
+    }
+
+    pub(crate) use {assert_event_matches, with_lock};
+}

--- a/crates/shared/src/event/domain_event.rs
+++ b/crates/shared/src/event/domain_event.rs
@@ -23,7 +23,6 @@ pub enum DomainEvent {
 
     // telemetry events
     ReportSent(),
-    ReportConsumed(),
 }
 
 impl DomainEvent {

--- a/crates/shared/src/event/topic.rs
+++ b/crates/shared/src/event/topic.rs
@@ -30,7 +30,6 @@ impl From<&DomainEvent> for Topic {
             WakeUp => System,
 
             ReportSent() => Telemetry,
-            ReportConsumed() => Telemetry,
         }
     }
 }


### PR DESCRIPTION
- renamed KOSError into CharonError
- made actor's spawn function return Result
- made evdev input abstracted with port/adapter for testability
- added tests for KeyScanner to test ungrabbing logic
- cleaned up the codebase by removing number of unwraps
- introduced lru_cache in telemetry to drop unhandled events after given time
- fixed bug in Typist preventing that was stopping it after typing the first character