### PR TITLE
Restart/Upgrade workflow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -212,6 +262,7 @@ dependencies = [
  "async-trait",
  "charond",
  "chrono",
+ "clap",
  "crossterm",
  "eyre",
  "maiko",
@@ -271,6 +322,52 @@ dependencies = [
  "wasm-bindgen",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "clap"
+version = "4.5.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75ca66430e33a14957acc24c5077b503e7d374151b2b4b3a10c83b4ceb4be0e"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793207c7fa6300a0608d1080b858e5fdbe713cdc1c8db9fb17777d8a13e63df0"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "compact_str"
@@ -1137,6 +1234,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1473,6 +1576,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl"
@@ -1813,7 +1922,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -134,6 +134,10 @@ You’re very welcome to get involved.
 Open issues, suggest features, or just come say hi in Discussions.
 No pressure, no CLA, just curiosity and a bit of ghostly magic.
 
+## Getting Started
+
+See the [Raspberry Pi 5 Setup Guide](docs/rp5-setup.md) for complete instructions on setting up Charon on your Pi.
+
 ## Testing your devices
 
 Use `evtest <input_file>`

--- a/charon-client/Cargo.toml
+++ b/charon-client/Cargo.toml
@@ -12,6 +12,7 @@ description = "Charon TUI client - keyboard companion interface"
 async-trait = "0.1.89"
 charond = { path = "../charon-daemon" }
 chrono.workspace = true
+clap = { version = "4.5.56", features = ["derive", "string"] }
 crossterm = { version = "0.29.0", features = ["serde", "event-stream"] }
 eyre.workspace = true
 maiko.workspace = true

--- a/charon-client/src/app.rs
+++ b/charon-client/src/app.rs
@@ -23,7 +23,7 @@ use tokio::{
 use tracing::{debug, error, info, warn};
 
 use crate::{
-    domain::{AppEvent, Command, Context},
+    domain::{AppEvent, Command, Context, TickAction},
     root::AppManager,
     tui::{Event as TuiEvent, Tui},
 };
@@ -31,8 +31,6 @@ use crate::{
 pub struct App {
     ctx: Arc<Context>,
     app_mngr: AppManager,
-    should_quit: bool,
-    should_suspend: bool,
     app_event_tx: mpsc::UnboundedSender<AppEvent>,
     app_event_rx: mpsc::UnboundedReceiver<AppEvent>,
     command_tx: mpsc::UnboundedSender<Command>,
@@ -49,8 +47,6 @@ impl App {
         Ok(Self {
             ctx,
             app_mngr,
-            should_quit: false,
-            should_suspend: false,
             app_event_tx,
             app_event_rx,
             command_tx,
@@ -72,53 +68,64 @@ impl App {
         let (reader, writer) = sock.into_split();
         self.sock_writer = Some(BufWriter::new(writer));
         let mut reader = BufReader::new(reader);
+        let mut action;
 
         loop {
-            self.tick(&mut tui, &mut reader).await?;
-            if self.should_suspend {
-                tui.suspend()?;
-                self.command_tx.send(Command::ResumeApp)?;
-                self.command_tx.send(Command::ClearScreen)?;
-                // tui.mouse(true);
-                tui.enter()?;
-            } else if self.should_quit {
-                tui.stop()?;
-                break;
+            action = self.tick(&mut tui, &mut reader).await?;
+            match action {
+                TickAction::Suspend => {
+                    tui.suspend()?;
+                    self.command_tx.send(Command::ResumeApp)?;
+                    self.command_tx.send(Command::ClearScreen)?;
+                    // tui.mouse(true);
+                    tui.enter()?;
+                }
+                TickAction::Quit | TickAction::Restart => {
+                    tui.stop()?;
+                    break;
+                }
+                _ => {}
             }
         }
         tui.exit()?;
+        if action == TickAction::Restart {
+            info!("Restarting client");
+            let _ = spawn_blocking(|| {
+                std::process::Command::new(std::env::current_exe().unwrap())
+                    .args(std::env::args().skip(1))
+                    .status()
+            })
+            .await?;
+        }
         Ok(())
-    }
-
-    pub fn stop(&mut self) {
-        self.should_quit = true;
     }
 
     pub async fn tick(
         &mut self,
         tui: &mut Tui,
         reader: &mut BufReader<OwnedReadHalf>,
-    ) -> eyre::Result<()> {
+    ) -> eyre::Result<TickAction> {
         let mut line = String::new();
+        let action: TickAction;
         select! {
             event = tui.next_event() => {
                 let event = event.ok_or_eyre("TUI event channel closed")?;
-                self.handle_tui_event(event).await?;
+                action = self.handle_tui_event(event).await?;
             }
             event = self.app_event_rx.recv() => {
                 let event = event.ok_or_eyre("App event channel closed")?;
-                self.handle_app_event(event, tui).await?;
+                action = self.handle_app_event(event, tui).await?;
             }
             command = self.command_rx.recv() => {
                 let command = command.ok_or_eyre("Command event channel closed")?;
-                self.handle_command(command, tui).await?;
+                action = self.handle_command(command, tui).await?;
             }
             line_res = reader.read_line(&mut line) => {
                 let bytes = line_res?;
-                self.handle_daemon_event(bytes, line).await?;
+                action = self.handle_daemon_event(bytes, line).await?;
             }
         }
-        Ok(())
+        Ok(action)
     }
 
     fn render(&mut self, tui: &mut Tui) -> eyre::Result<()> {
@@ -126,7 +133,7 @@ impl App {
         Ok(())
     }
 
-    async fn handle_tui_event(&mut self, event: TuiEvent) -> eyre::Result<()> {
+    async fn handle_tui_event(&mut self, event: TuiEvent) -> eyre::Result<TickAction> {
         let app_event_tx = self.app_event_tx.clone();
         let command_tx = self.command_tx.clone();
         match event {
@@ -134,13 +141,18 @@ impl App {
             TuiEvent::Tick => self.handle_tick()?,
             TuiEvent::Render => command_tx.send(Command::Render)?,
             TuiEvent::Resize(x, y) => app_event_tx.send(AppEvent::Resize(x, y))?,
-            TuiEvent::Key(key) => self.handle_key_event(key)?,
+            TuiEvent::Key(key) => return self.handle_key_event(key),
             _ => {}
         }
-        Ok(())
+        Ok(TickAction::None)
     }
 
-    async fn handle_app_event(&mut self, event: AppEvent, tui: &mut Tui) -> eyre::Result<()> {
+    async fn handle_app_event(
+        &mut self,
+        event: AppEvent,
+        tui: &mut Tui,
+    ) -> eyre::Result<TickAction> {
+        let mut action = TickAction::default();
         if !matches!(
             event,
             AppEvent::Tick(..) | AppEvent::Backend(CharonEvent::CurrentStats(..))
@@ -148,7 +160,7 @@ impl App {
             debug!("{event:?}");
         }
         match event {
-            AppEvent::Quit => self.should_quit = true,
+            AppEvent::Quit => action = TickAction::Quit,
             AppEvent::Resize(w, h) => self.handle_resize(tui, w, h)?,
             _ => {}
         }
@@ -156,34 +168,39 @@ impl App {
         if let Some(cmd) = self.app_mngr.update(&event).await {
             self.command_tx.send(cmd)?;
         }
-        Ok(())
+        Ok(action)
     }
 
-    async fn handle_command(&mut self, command: Command, tui: &mut Tui) -> eyre::Result<()> {
+    async fn handle_command(
+        &mut self,
+        command: Command,
+        tui: &mut Tui,
+    ) -> eyre::Result<TickAction> {
+        let mut action = TickAction::default();
         match command {
             Command::SuspendTUI => tui.exit()?,
             Command::ResumeTUI => {
                 tui.enter()?;
                 tui.terminal.clear()?;
             }
-            Command::SuspendApp => self.should_suspend = true,
-            Command::ResumeApp => self.should_suspend = false,
+            Command::SuspendApp => action = TickAction::Suspend,
+            Command::ResumeApp => action = TickAction::Resume,
             Command::ClearScreen => tui.terminal.clear()?,
             Command::Render => self.render(tui)?,
             Command::SendEvent(event) => self.send_to_daemon(&event).await?,
-            Command::Quit => self.should_quit = true,
+            Command::Quit => action = TickAction::Quit,
             Command::ExitApp => self.switch_app("menu")?,
+            Command::Restart => action = TickAction::Restart,
             Command::RunApp(app) => self.switch_app(app)?,
             Command::RunExternal(path, args) => self.run_external(path, args, tui).await?,
         }
-        Ok(())
+        Ok(action)
     }
 
-    async fn handle_daemon_event(&mut self, size: usize, line: String) -> eyre::Result<()> {
+    async fn handle_daemon_event(&mut self, size: usize, line: String) -> eyre::Result<TickAction> {
         if size == 0 {
             warn!("Connection closed by daemon");
-            self.should_quit = true;
-            return Ok(());
+            return Ok(TickAction::Quit);
         }
         let msg_line = line.trim();
         if !msg_line.is_empty() {
@@ -191,7 +208,7 @@ impl App {
             self.app_event_tx
                 .send(AppEvent::Backend(envelope.event().clone()))?;
         }
-        Ok(())
+        Ok(TickAction::None)
     }
 
     fn handle_resize(&mut self, tui: &mut Tui, w: u16, h: u16) -> eyre::Result<()> {
@@ -208,19 +225,20 @@ impl App {
         Ok(())
     }
 
-    fn handle_key_event(&mut self, key: KeyEvent) -> eyre::Result<()> {
+    fn handle_key_event(&mut self, key: KeyEvent) -> eyre::Result<TickAction> {
+        let mut action = TickAction::default();
         match (key.code, key.modifiers) {
             (KeyCode::Char('c'), KeyModifiers::CONTROL) => {
                 info!("Quitting on Ctrl+C");
-                self.should_quit = true;
+                action = TickAction::Quit;
             }
             (KeyCode::Char('z'), KeyModifiers::CONTROL) => {
                 info!("Suspending");
-                self.should_suspend = true;
+                action = TickAction::Suspend;
             }
             _ => self.app_event_tx.send(AppEvent::Key(key))?,
         }
-        Ok(())
+        Ok(action)
     }
 
     fn switch_app(&mut self, name: &'static str) -> eyre::Result<()> {

--- a/charon-client/src/app.rs
+++ b/charon-client/src/app.rs
@@ -96,8 +96,7 @@ impl App {
             );
             use std::os::unix::process::CommandExt;
             let err = std::process::Command::new(&self.ctx.config.upgrade_script).exec();
-            // exec() only returns on error
-            return Err(err.into());
+            return Err(err.into()); // exec() only returns on error
         }
         Ok(())
     }
@@ -186,7 +185,7 @@ impl App {
                 tui.terminal.clear()?;
             }
             Command::SuspendApp => action = TickAction::Suspend,
-            Command::ResumeApp => action = TickAction::Resume,
+            Command::ResumeApp => {}
             Command::ClearScreen => tui.terminal.clear()?,
             Command::Render => self.render(tui)?,
             Command::SendEvent(event) => self.send_to_daemon(&event).await?,

--- a/charon-client/src/apps/menu/menu.rs
+++ b/charon-client/src/apps/menu/menu.rs
@@ -69,7 +69,7 @@ impl UiApp for Menu {
                     KeyCode::Char('k') => Command::RunApp("keymap"),
                     KeyCode::Char('p') => Command::RunApp("password"),
                     KeyCode::Char('q') => Command::Quit,
-                    KeyCode::Char('r') => Command::Restart,
+                    KeyCode::Char('u') => Command::Upgrade,
                     KeyCode::Char('s') => Command::RunApp("stats"),
                     _ => return None,
                 };

--- a/charon-client/src/apps/menu/menu.rs
+++ b/charon-client/src/apps/menu/menu.rs
@@ -69,6 +69,7 @@ impl UiApp for Menu {
                     KeyCode::Char('k') => Command::RunApp("keymap"),
                     KeyCode::Char('p') => Command::RunApp("password"),
                     KeyCode::Char('q') => Command::Quit,
+                    KeyCode::Char('r') => Command::Restart,
                     KeyCode::Char('s') => Command::RunApp("stats"),
                     _ => return None,
                 };

--- a/charon-client/src/cli.rs
+++ b/charon-client/src/cli.rs
@@ -1,0 +1,22 @@
+use std::path::PathBuf;
+
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+pub struct Cli {
+    #[arg(
+        short,
+        long,
+        value_parser,
+        default_value = default_config_path().into_os_string(),
+        help = "Path to the configuration file"
+    )]
+    pub config: PathBuf,
+}
+
+fn default_config_path() -> PathBuf {
+    let mut path = PathBuf::new();
+    path.push(std::env::var("XDG_CONFIG_HOME").unwrap_or("~/.config".into()));
+    path.push("charon/tui.toml");
+    path
+}

--- a/charon-client/src/config.rs
+++ b/charon-client/src/config.rs
@@ -18,14 +18,11 @@ pub struct AppConfig {
     pub keyboard_layouts_dir: PathBuf,
     pub keymaps_dir: PathBuf,
     pub wisdoms_file: PathBuf,
+    pub upgrade_script: PathBuf,
 }
 
 impl AppConfig {
-    pub fn from_file() -> eyre::Result<Self> {
-        let mut path = PathBuf::new();
-        path.push(std::env::var("XDG_CONFIG_HOME")?);
-        path.push("charon/tui.toml");
-
+    pub fn from_file(path: PathBuf) -> eyre::Result<Self> {
         if !path.exists() {
             tracing::warn!(
                 "Couldn't find config file at {:?}. Starting with default configuration",
@@ -69,6 +66,8 @@ impl Default for AppConfig {
             password_app: "passepartui".into(),
             editor_app: "nvim".into(),
             wisdoms_file: PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("data/wisdoms.json"),
+            upgrade_script: PathBuf::from(std::env::var("HOME").unwrap_or_else(|_| "/tmp".into()))
+                .join(".local/charon.service/upgrade.sh"),
         }
     }
 }

--- a/charon-client/src/domain/command.rs
+++ b/charon-client/src/domain/command.rs
@@ -8,6 +8,7 @@ use strum::Display;
 #[non_exhaustive]
 pub enum Command {
     Quit,
+    Restart,
     ExitApp,
     Render,
     RunApp(&'static str),

--- a/charon-client/src/domain/command.rs
+++ b/charon-client/src/domain/command.rs
@@ -8,7 +8,7 @@ use strum::Display;
 #[non_exhaustive]
 pub enum Command {
     Quit,
-    Restart,
+    Upgrade,
     ExitApp,
     Render,
     RunApp(&'static str),

--- a/charon-client/src/domain/mod.rs
+++ b/charon-client/src/domain/mod.rs
@@ -2,8 +2,10 @@
 mod app_event;
 mod command;
 mod context;
+mod tick_action;
 pub mod traits;
 
 pub use app_event::AppEvent;
 pub use command::Command;
 pub use context::Context;
+pub(crate) use tick_action::TickAction;

--- a/charon-client/src/domain/tick_action.rs
+++ b/charon-client/src/domain/tick_action.rs
@@ -1,0 +1,11 @@
+use strum::Display;
+
+#[derive(Debug, Clone, PartialEq, Eq, Display, Default)]
+pub enum TickAction {
+    Quit,
+    Restart,
+    Suspend,
+    Resume,
+    #[default]
+    None,
+}

--- a/charon-client/src/domain/tick_action.rs
+++ b/charon-client/src/domain/tick_action.rs
@@ -3,7 +3,7 @@ use strum::Display;
 #[derive(Debug, Clone, PartialEq, Eq, Display, Default)]
 pub enum TickAction {
     Quit,
-    Restart,
+    Upgrade,
     Suspend,
     Resume,
     #[default]

--- a/charon-client/src/domain/tick_action.rs
+++ b/charon-client/src/domain/tick_action.rs
@@ -5,7 +5,6 @@ pub enum TickAction {
     Quit,
     Upgrade,
     Suspend,
-    Resume,
     #[default]
     None,
 }

--- a/charon-client/src/main.rs
+++ b/charon-client/src/main.rs
@@ -3,6 +3,7 @@
 
 pub mod app;
 pub mod apps;
+mod cli;
 pub mod components;
 pub mod config;
 pub mod domain;
@@ -13,6 +14,7 @@ pub mod util;
 
 use std::{collections::HashMap, sync::Arc};
 
+use clap::Parser;
 use tracing::error;
 use tracing_appender::rolling;
 use tracing_subscriber::EnvFilter;
@@ -33,8 +35,10 @@ use crate::{
 async fn main() -> eyre::Result<()> {
     init_logging();
 
+    let args = cli::Cli::parse();
+
     let ctx = &Arc::new(Context {
-        config: AppConfig::from_file()?,
+        config: AppConfig::from_file(args.config)?,
     });
 
     let apps: HashMap<&'static str, Box<dyn UiApp + Send + Sync>> = vec![
@@ -69,7 +73,7 @@ fn menu_items() -> Vec<MenuItem> {
         ("Calendar", '\u{eab0}', "l"),
         ("Calculator", '\u{f00ec}', "c"),
         ("Keymaps", '\u{f030c}', "k"),
-        ("Restart", '\u{f0709}', "r"),
+        ("Upgrade", '\u{f0709}', "u"),
         ("Quit", '\u{f0a48}', "q"),
     ]
     .iter()

--- a/charon-client/src/main.rs
+++ b/charon-client/src/main.rs
@@ -66,10 +66,10 @@ fn menu_items() -> Vec<MenuItem> {
         ("Editor", '\u{ed39}', "e"),
         ("Stats", '\u{f04c5}', "s"),
         ("Passwords", '\u{f07f5}', "p"),
-        ("Calendar", '\u{f07f5}', "l"),
-        ("Calculator", '\u{f07f5}', "c"),
-        ("Keymaps", '\u{f07f5}', "k"),
-        ("Game", '\u{f07f5}', "g"),
+        ("Calendar", '\u{eab0}', "l"),
+        ("Calculator", '\u{f00ec}', "c"),
+        ("Keymaps", '\u{f030c}', "k"),
+        ("Restart", '\u{f0709}', "r"),
         ("Quit", '\u{f0a48}', "q"),
     ]
     .iter()

--- a/docs/rp5-setup.md
+++ b/docs/rp5-setup.md
@@ -1,0 +1,390 @@
+# Raspberry Pi 5 Setup Guide
+
+This guide walks you through setting up a Raspberry Pi 5 as a USB HID gadget for Charon.
+
+---
+
+## Prerequisites
+
+### Hardware
+
+- Raspberry Pi 5
+- USB-C cable (for connecting RP5 to the host computer)
+- MicroSD card (16GB+ recommended)
+- USB keyboard (the one you want to pass through)
+- Optional: small display for the TUI client
+
+### Software
+
+- Raspberry Pi OS Lite (64-bit) - Bookworm or later
+- Rust toolchain (installed during setup)
+
+---
+
+## Step 1: Flash Raspberry Pi OS
+
+1. Download [Raspberry Pi Imager](https://www.raspberrypi.com/software/)
+2. Flash **Raspberry Pi OS Lite (64-bit)** to your SD card
+3. In the imager settings, enable SSH and configure WiFi if needed
+4. Boot the Pi and SSH in
+
+---
+
+## Step 2: Configure USB Gadget Mode
+
+The RP5 needs to act as a USB HID device (keyboard) to the host computer. This requires enabling the `dwc2` USB driver in gadget mode.
+
+### Enable dwc2 overlay
+
+Edit `/boot/firmware/config.txt`:
+
+```bash
+sudo nano /boot/firmware/config.txt
+```
+
+Add at the end:
+
+```ini
+dtoverlay=dwc2
+```
+
+### Load dwc2 module at boot
+
+Edit `/etc/modules`:
+
+```bash
+sudo nano /etc/modules
+```
+
+Add:
+
+```
+dwc2
+libcomposite
+```
+
+### Reboot
+
+```bash
+sudo reboot
+```
+
+---
+
+## Step 3: Create HID Gadget Configuration
+
+Create a script to configure the USB gadget. This sets up a composite device that presents itself as a keyboard to the host.
+
+Create `/usr/local/bin/charon-gadget`:
+
+```bash
+sudo nano /usr/local/bin/charon-gadget
+```
+
+```bash
+#!/bin/bash
+
+# Charon USB HID Gadget Setup
+# Based on https://github.com/rikka-chunibyo/HIDPi
+
+GADGET_DIR="/sys/kernel/config/usb_gadget/charon"
+
+# Exit if already configured
+if [ -d "$GADGET_DIR" ]; then
+    echo "Gadget already configured"
+    exit 0
+fi
+
+# Load libcomposite if not loaded
+modprobe libcomposite
+
+# Create gadget directory
+mkdir -p "$GADGET_DIR"
+cd "$GADGET_DIR"
+
+# USB IDs (use your own or keep these generic ones)
+echo 0x1d6b > idVendor  # Linux Foundation
+echo 0x0104 > idProduct # Multifunction Composite Gadget
+echo 0x0100 > bcdDevice # v1.0.0
+echo 0x0200 > bcdUSB    # USB 2.0
+
+# Device strings
+mkdir -p strings/0x409
+echo "fedcba9876543210" > strings/0x409/serialnumber
+echo "Charon" > strings/0x409/manufacturer
+echo "Charon Keyboard" > strings/0x409/product
+
+# Create HID function (keyboard)
+mkdir -p functions/hid.usb0
+echo 1 > functions/hid.usb0/protocol      # Keyboard
+echo 1 > functions/hid.usb0/subclass      # Boot interface subclass
+echo 8 > functions/hid.usb0/report_length # 8-byte reports
+
+# HID report descriptor for a standard keyboard
+echo -ne '\x05\x01\x09\x06\xa1\x01\x05\x07\x19\xe0\x29\xe7\x15\x00\x25\x01\x75\x01\x95\x08\x81\x02\x95\x01\x75\x08\x81\x03\x95\x05\x75\x01\x05\x08\x19\x01\x29\x05\x91\x02\x95\x01\x75\x03\x91\x03\x95\x06\x75\x08\x15\x00\x25\x65\x05\x07\x19\x00\x29\x65\x81\x00\xc0' > functions/hid.usb0/report_desc
+
+# Create configuration
+mkdir -p configs/c.1/strings/0x409
+echo "Config 1: HID Keyboard" > configs/c.1/strings/0x409/configuration
+echo 250 > configs/c.1/MaxPower
+
+# Link function to configuration
+ln -s functions/hid.usb0 configs/c.1/
+
+# Enable gadget (bind to UDC)
+ls /sys/class/udc > UDC
+
+echo "Charon HID gadget configured"
+```
+
+Make it executable:
+
+```bash
+sudo chmod +x /usr/local/bin/charon-gadget
+```
+
+### Run at boot
+
+Create a systemd service `/etc/systemd/system/charon-gadget.service`:
+
+```bash
+sudo nano /etc/systemd/system/charon-gadget.service
+```
+
+```ini
+[Unit]
+Description=Charon USB HID Gadget
+After=sysinit.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/charon-gadget
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Enable it:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable charon-gadget.service
+```
+
+---
+
+## Step 4: Set Up Input Device Permissions
+
+Charon needs access to evdev input devices. Create a udev rule:
+
+```bash
+sudo nano /etc/udev/rules.d/99-charon-input.rules
+```
+
+```
+# Allow charon group to access input devices
+SUBSYSTEM=="input", GROUP="input", MODE="0660"
+
+# Allow access to HID gadget
+KERNEL=="hidg*", GROUP="input", MODE="0660"
+```
+
+Create a `charon` user and add to required groups:
+
+```bash
+sudo useradd -r -s /bin/false charon
+sudo usermod -a -G input charon
+```
+
+Reload udev:
+
+```bash
+sudo udevadm control --reload
+sudo udevadm trigger
+```
+
+---
+
+## Step 5: Install Rust
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+source ~/.cargo/env
+```
+
+---
+
+## Step 6: Build Charon
+
+Clone and build:
+
+```bash
+git clone https://github.com/your-repo/charon.git
+cd charon
+cargo build --release
+```
+
+The binaries will be at:
+- `target/release/charond` - the daemon
+- `target/release/charon-tui` - the TUI client
+
+Install them:
+
+```bash
+sudo cp target/release/charond /usr/local/bin/
+sudo cp target/release/charon-tui /usr/local/bin/
+```
+
+---
+
+## Step 7: Configure Charon
+
+Create the configuration directory and file:
+
+```bash
+sudo mkdir -p /etc/charon
+sudo nano /etc/charon/config.toml
+```
+
+Minimal configuration:
+
+```toml
+[hid]
+device = "/dev/hidg0"
+
+[input]
+# Find your keyboard with: ls -la /dev/input/by-id/
+# Look for entries ending in -event-kbd
+devices = [
+    "/dev/input/by-id/usb-YOUR_KEYBOARD-event-kbd"
+]
+
+[keymap]
+layout = "en_us"
+
+[telemetry]
+enabled = false
+```
+
+To find your keyboard device:
+
+```bash
+ls -la /dev/input/by-id/ | grep kbd
+```
+
+---
+
+## Step 8: Create Systemd Services
+
+### Daemon service
+
+```bash
+sudo nano /etc/systemd/system/charond.service
+```
+
+```ini
+[Unit]
+Description=Charon Keyboard Daemon
+After=charon-gadget.service
+Requires=charon-gadget.service
+
+[Service]
+Type=simple
+User=charon
+ExecStart=/usr/local/bin/charond --config /etc/charon/config.toml
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Enable and start:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable charond.service
+sudo systemctl start charond.service
+```
+
+Check status:
+
+```bash
+sudo systemctl status charond.service
+sudo journalctl -u charond.service -f
+```
+
+---
+
+## Step 9: Connect and Test
+
+1. Connect a USB keyboard to one of the RP5's USB-A ports
+2. Connect the RP5's USB-C port to your host computer
+3. The host should detect a new keyboard device
+4. Type on your keyboard - keystrokes should pass through to the host
+
+---
+
+## Troubleshooting
+
+### Gadget not appearing on host
+
+Check if gadget is configured:
+
+```bash
+ls /sys/kernel/config/usb_gadget/charon/
+```
+
+Check UDC binding:
+
+```bash
+cat /sys/kernel/config/usb_gadget/charon/UDC
+```
+
+Verify dwc2 is loaded:
+
+```bash
+lsmod | grep dwc2
+```
+
+### Permission denied errors
+
+Ensure the charon user has correct group memberships:
+
+```bash
+groups charon
+```
+
+Check device permissions:
+
+```bash
+ls -la /dev/input/event*
+ls -la /dev/hidg0
+```
+
+### Keystrokes not passing through
+
+Check charond logs:
+
+```bash
+sudo journalctl -u charond.service -f
+```
+
+Test input device manually:
+
+```bash
+sudo evtest /dev/input/by-id/usb-YOUR_KEYBOARD-event-kbd
+```
+
+### High latency
+
+Ensure you're using USB 2.0 or higher cable. The RP5 USB-C port supports USB 2.0 in gadget mode.
+
+---
+
+## Next Steps
+
+- [Configure QMK integration](qmk.md) for programmable keyboards
+- [Set up telemetry](../setup/README.md) for typing statistics
+- Configure the TUI client for your display

--- a/docs/rp5-setup.md
+++ b/docs/rp5-setup.md
@@ -34,6 +34,8 @@ This guide walks you through setting up a Raspberry Pi 5 as a USB HID gadget for
 
 The RP5 needs to act as a USB HID device (keyboard) to the host computer. This requires enabling the `dwc2` USB driver in gadget mode.
 
+> **Alternative:** For a simpler setup, check out [HIDPi](https://github.com/rikka-chunibyo/HIDPi) which automates most of the gadget configuration. The manual steps below are provided for reference and customization.
+
 ### Enable dwc2 overlay
 
 Edit `/boot/firmware/config.txt`:

--- a/justfile
+++ b/justfile
@@ -56,8 +56,8 @@ build-rp5-client:
 
 # Deploy binaries to RP5 (set RP5_HOST env var or defaults to charon.local)
 deploy: build-rp5
-    scp target/{{rp5_target}}/release/charond {{rp5_host}}:~/Downloads
-    scp target/{{rp5_target}}/release/charon-tui {{rp5_host}}:~/Downloads
+    scp target/{{rp5_target}}/release/charond {{rp5_host}}:~/.local/bin
+    scp target/{{rp5_target}}/release/charon-tui {{rp5_host}}:~/.local/bin
     @echo "Deployed to {{rp5_host}}"
 
 # ---------- Test ----------

--- a/setup/README.md
+++ b/setup/README.md
@@ -1,5 +1,7 @@
 # Charon setup files
 
+For complete Raspberry Pi 5 setup instructions, see [docs/rp5-setup.md](../docs/rp5-setup.md).
+
 This folder contains files that configure or create external services used by Charon.
 They are all optional, although some of them, like `telemetry`, are related to important
 part of Charon's logic.

--- a/setup/README.md
+++ b/setup/README.md
@@ -8,11 +8,15 @@ part of Charon's logic.
 
 ## Folders
 
+- `charon`: systemd service files and helper scripts for running Charon in user space.
+  Includes the daemon service unit, desktop entry for TUI autostart, and scripts for
+  running and restarting Charon.
+
 - `telemetry`: configuration of [Prometheus](https://prometheus.io/) and
   [Pushgateway](https://github.com/prometheus/pushgateway).
   This is crucial for collecting any statistics while typing - like WPM, key-presses
   count etc. The entire telemetry functionality can be disabled in the config file
-  (`enbale_telemetry` option), but when enabled, Prometheus must be configured
+  (`enable_telemetry` option), but when enabled, Prometheus must be configured.
 
 - `qmk`: important only when Charon works with a QMK-powered programmable keyboard
   and only when [Raw HID](https://docs.qmk.fm/features/rawhid) is enabled on the keyboard

--- a/setup/charon/charon-client.desktop
+++ b/setup/charon/charon-client.desktop
@@ -1,0 +1,10 @@
+# Copy this file to ~/.config/autostart/ to enable autostart of
+# the Charon TUI client in a fullscreen terminal window using Kitty.
+
+[Desktop Entry]
+Type=Application
+Name=Charon Client
+Exec=kitty --hold --start-as=fullscreen -e /home/charon/.local/charon.service/run-charon-tui.sh
+Hidden=false
+X-GNOME-Autostart-enabled=true
+

--- a/setup/charon/charond.service
+++ b/setup/charon/charond.service
@@ -1,0 +1,19 @@
+# Copy this file to ~/.config/systemd/user/charond.service
+
+[Unit]
+Description=Charon Daemon
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=simple
+ExecStartPre=/usr/bin/sleep 1
+ExecStart=%h/.local/charon.service/charond
+Restart=on-failure
+RestartSec=3
+
+StandardOutput=append:%h/.local/charon.service/charond-stdout.log
+StandardError=append:%h/.local/charon.service/charond-error.log
+
+[Install]
+WantedBy=default.target

--- a/setup/charon/restart-charon.sh
+++ b/setup/charon/restart-charon.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Copy new binaries and restart the charond service
+# Assumes that the charond service is already set up and running
+# This file should be copied to ~/.local/charon.service/restart-charon.sh
+# TUI's config should be pointing to this file, to make upgrade option to work
+# (`upgrade_script` option).
+
+systemctl --user stop charond.service
+
+cp ~/.local/bin/charond ~/.local/charon.service/charond
+cp ~/.local/bin/charon-tui ~/.local/charon.service/charon-tui
+
+systemctl --user start charond.service
+
+exec ~/.local/charon.service/charon-tui --config ~/.config/charon/tui.toml
+

--- a/setup/charon/run-charon-tui.sh
+++ b/setup/charon/run-charon-tui.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# This script runs the charon TUI with the specified config file.
+# It should be copied to ~/.local/charon.service/run-charon-tui.sh
+# The file used by the auto-start desktop entry.
+
+exec ~/.local/charon.service/charon-tui --config ~/.config/charon/tui.toml


### PR DESCRIPTION
- Thanx to changes in flake.nix compilation is possible now outside of Pi
- `just deploy` automatically builds for pi and sends files to the device
- client has "Upgrade" option , that takes latest binaries and restart daemon and itself (fixes #43)
- daemon runs now as systemd service (in user space)
- charon (client and daemon) starts automatically on boot